### PR TITLE
Quality of life improvements to allow easier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Snapshot versions are available in the [JFrog Artifactory repository](https://os
 
 ## Configuration
 
+### Configuring which checkers to use
+
 It is possible to configure the checkers you want to enable using the `checkerFramework.checkers` property.
 
 For example:
@@ -58,6 +60,35 @@ checkerFramework {
 By default, only the `NullnessChecker` is enabled.
 
 You can find out what checkers are available in the [Checker Framework Manual](https://checkerframework.org/manual/#introduction).
+
+### Providing checker-specific options to the compiler
+
+You can set the `checkerFramework.extraJavacArgs` property in order to pass additional options to the compiler when running
+a typechecker.
+
+For example, to use a stub file:
+
+```groovy
+checkerFramework {
+  extraJavacArgs = [
+    '-Astubs=/path/to/my/stub/file.astub'
+  ]
+}
+```
+
+### Configuring third-party checkers
+
+To use a third-party typechecker (i.e. one that is not distributed with the Checker Framework),
+add a dependency to the `checkerFramework` dependency configuration.
+
+For example, to use the [Glacier](http://mcoblenz.github.io/Glacier/) immutability checker:
+
+```groovy
+dependencies {
+  ...
+  checkerFramework 'edu.cmu.cs.glacier:glacier:0.1'
+}
+```
 
 ## License
 

--- a/src/main/groovy/com/jaredsburrows/checkerframework/CheckerExtension.groovy
+++ b/src/main/groovy/com/jaredsburrows/checkerframework/CheckerExtension.groovy
@@ -4,5 +4,5 @@ class CheckerExtension {
   List<String> checkers = ["org.checkerframework.checker.nullness.NullnessChecker"]
 
   // A list of extra options to pass directly to javac when running typecheckers
-  List<String> extraJavacOptions = []
+  List<String> extraJavacArgs = []
 }

--- a/src/main/groovy/com/jaredsburrows/checkerframework/CheckerExtension.groovy
+++ b/src/main/groovy/com/jaredsburrows/checkerframework/CheckerExtension.groovy
@@ -2,4 +2,7 @@ package com.jaredsburrows.checkerframework
 
 class CheckerExtension {
   List<String> checkers = ["org.checkerframework.checker.nullness.NullnessChecker"]
+
+  // A list of extra options to pass directly to javac when running typecheckers
+  List<String> extraJavacOptions = []
 }

--- a/src/main/groovy/com/jaredsburrows/checkerframework/CheckerPlugin.groovy
+++ b/src/main/groovy/com/jaredsburrows/checkerframework/CheckerPlugin.groovy
@@ -98,7 +98,7 @@ final class CheckerPlugin implements Plugin<Project> {
         compile.options.compilerArgs << "-processor" << userConfig.checkers.join(",")
       }
 
-      userConfig.extraJavacOptions.forEach({option -> compile.options.compilerArgs << option})
+      userConfig.extraJavacArgs.forEach({option -> compile.options.compilerArgs << option})
 
       ANDROID_IDS.each { id ->
         project.plugins.withId(id) {

--- a/src/main/groovy/com/jaredsburrows/checkerframework/CheckerPlugin.groovy
+++ b/src/main/groovy/com/jaredsburrows/checkerframework/CheckerPlugin.groovy
@@ -98,6 +98,8 @@ final class CheckerPlugin implements Plugin<Project> {
         compile.options.compilerArgs << "-processor" << userConfig.checkers.join(",")
       }
 
+      userConfig.extraJavacOptions.forEach({option -> compile.options.compilerArgs << option})
+
       ANDROID_IDS.each { id ->
         project.plugins.withId(id) {
           options.bootClasspath = System.getProperty("sun.boot.class.path") + ":" + options.bootClasspath


### PR DESCRIPTION
This change has two parts, both of which are motivated by some of my experiences trying this plugin out on an Android app with a checker that isn't distributed with the Checker Framework.

The first change is the addition of an easy way to add custom arguments via the plugin. This is very convenient when using stub files or other Checker Framework options, like `-AstubDebug`.

The other is instructions in the README about how to use the plugin with a third party checker.

I tested both locally.